### PR TITLE
fix(SocketHandler): recvが改行まで文字列受信を待機する仕様に修正

### DIFF
--- a/pkg/application/useCases/RecieveMsgUseCase.cpp
+++ b/pkg/application/useCases/RecieveMsgUseCase.cpp
@@ -15,7 +15,7 @@ RecievedMsgDTO RecieveMsgUseCase::recieve(const MonitorSocketEventDTO &event) {
   } catch (const std::runtime_error &e) {
     throw std::runtime_error(std::string("RecieveMsgUseCase: ") + e.what());
   }
-  logger->tracess() << "Message recieved from client: " << client->getAddress()
-                    << " (fd: " << client->getSocketFd() << ")";
+  logger->tracess() << "Message from client: " << client->getAddress()
+                    << " (fd: " << client->getSocketFd() << ") " << msg;
   return (RecievedMsgDTO(msg, client));
 }

--- a/pkg/application/useCases/SendMsgFromServerUseCase.cpp
+++ b/pkg/application/useCases/SendMsgFromServerUseCase.cpp
@@ -15,7 +15,7 @@ void SendMsgFromServerUseCase::send(IClientAggregateRoot *client, const SendMsgD
     logger->errorss() << "Failed to send message to client: " << client->getAddress()
                       << " (fd: " << fd << ")";
   } else {
-    logger->tracess() << "Message sent to client: " << client->getAddress() << " (fd: " << fd << ")"
+    logger->tracess() << "Message to client: " << client->getAddress() << " (fd: " << fd << ")"
                       << message;
   }
 }

--- a/pkg/infra/socket/SocketHandler.cpp
+++ b/pkg/infra/socket/SocketHandler.cpp
@@ -121,12 +121,22 @@ std::string SocketHandler::receiveMsg(const int &targetSocket) {
   if (!this->_isListening) {
     throw std::runtime_error("socket is not listening");
   }
+
+  std::string recieved;
   char recv_buf[this->_maxBufferSize];
-  ssize_t recv_size = recv(targetSocket, recv_buf, this->_maxBufferSize, 0);
-  if (recv_size == -1) {
-    throw std::runtime_error("recieve msg failed");
+  ssize_t bytes_received;
+
+  while ((bytes_received = recv(targetSocket, recv_buf, this->_maxBufferSize - 1, 0)) > 0) {
+    recv_buf[bytes_received] = '\0';
+    std::string recv_string = std::string(recv_buf);
+    size_t pos;
+    while ((pos = recv_string.find("\r\n")) != std::string::npos) {
+      recieved += recv_string.substr(0, pos);
+      return recieved;
+    }
+    recieved += recv_string;
   }
-  return std::string(recv_buf, recv_size);
+  return recieved;
 }
 
 void SocketHandler::setMaxConnections(const int maxConnections) {


### PR DESCRIPTION
```cpp
ssize_t status = server.sendMsg(clientMsg + "\r\n", client_socket);
```
このように、送信するメッセージには改行コードが必須な仕様にした。

---
`pkg`ディレクトリ内のメッセージ処理とロギングを改善するためのいくつかの変更が含まれています。変更点は、`SocketHandler`クラスを強化してメッセージ受信をより堅牢に処理するようにしたこと、そして新しいメッセージ処理ロジックに一致するようにテストケースを改良したことです。

メッセージ処理の改善点：

* [`pkg/infra/socket/SocketHandler.cpp`](diffhunk://#diff-7fbf8144b578b62b2f3a660d99b1de539d5975b9a91d28c5e7163d0fc1a6cc52R124-R139): `receiveMsg`メソッドを変更し、部分的なメッセージ受信を処理し、`\r\n`で示される完全なメッセージを受信するまでメッセージフラグメントを連結するようにしました。

テストケースの改良点：

* [`pkg/tests/infra/socket/test_SocketHandler.cpp`](diffhunk://#diff-0b1d47fe22bb6a9810815d67c3cb4e6921760a1f65ca5dd8ec65d77da72492ccL123-R147): `SendAndReceiveMessage`テストを、事前定義されたクライアントとサーバーのメッセージを使用し、`\r\n`をメッセージ区切り文字として含むように更新しました。

その他、ロギングに関しての修正があります。
* [`pkg/application/useCases/RecieveMsgUseCase.cpp`](diffhunk://#diff-9c7f72c69c4db47c2281cac9bae0393d2d2f16d8d229d6b1e7678cffe26b02ccL18-R19): `RecieveMsgUseCase::recieve`のロギングメッセージを受信したメッセージの内容を含むように更新しました。
* [`pkg/application/useCases/SendMsgFromServerUseCase.cpp`](diffhunk://#diff-1e3b3458fa1ea12129e981bb833116fa475a4d78f5bb8a7ef8f2b7266e30f47fL18-R18): `SendMsgFromServerUseCase::send`のロギングメッセージを送信したメッセージの内容を含むように更新しました。