### PR TITLE
patch(Logger): 呼び出したら例外をスローするfatalメソッドを追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -92,6 +92,9 @@
     "thread": "cpp",
     "typeinfo": "cpp",
     "cinttypes": "cpp",
-    "csignal": "cpp"
-  }
+    "csignal": "cpp",
+    "numbers": "cpp",
+    "semaphore": "cpp"
+  },
+
 }

--- a/pkg/application/serviceLocator/LoggerServiceLocator.hpp
+++ b/pkg/application/serviceLocator/LoggerServiceLocator.hpp
@@ -8,13 +8,33 @@
 #include <stdexcept>
 #include <string>
 
+/**
+ * @class LoggerServiceLocator
+ * @brief ロガーサービスのロケータクラス。
+ *
+ * このクラスは、異なるタイプのロガー（コンソール、ファイル、Sentry）を管理し、
+ * 必要に応じて初期化、取得、クリーンアップを行います。
+ */
 class LoggerServiceLocator {
 public:
-  enum loggerType {
-    CONSOLE = 1 << 0,
-    FILE = 1 << 1,
-  };
+  /**
+   * @enum LoggerServiceLocator::loggerType
+   * @brief ロガーのタイプを示す列挙型。
+   *
+   * - CONSOLE: コンソールロガー
+   * - FILE: ファイルロガー
+   * - SENTRY: Sentryロガー
+   */
+  enum loggerType { CONSOLE = 1 << 0, FILE = 1 << 1, SENTRY = 1 << 2 };
 
+  /**
+   * @fn static void LoggerServiceLocator::init(int type, std::string logFile = "")
+   * @brief ロガーを初期化します。
+   *
+   * @param type 初期化するロガーのタイプ（ビットマスク）。
+   * @param logFile ファイルロガーを使用する場合のログファイルのパス。
+   * @throws std::runtime_error ロガーが既に初期化されている場合、またはファイルロガーのログファイルが空の場合。
+   */
   static void init(int type, std::string logFile = "") {
     if (_logger != NULL) {
       throw std::runtime_error("LoggerServiceLocator is already initialized");
@@ -32,6 +52,13 @@ public:
     _logger->trace("Logger initialized");
   }
 
+  /**
+   * @fn static MultiLogger* LoggerServiceLocator::get()
+   * @brief 初期化されたロガーを取得します。
+   *
+   * @return 初期化されたMultiLoggerのポインタ。
+   * @throws std::runtime_error ロガーが初期化されていない場合。
+   */
   static MultiLogger *get() {
     if (_logger == NULL) {
       throw std::runtime_error("LoggerServiceLocator is not initialized");
@@ -39,6 +66,12 @@ public:
     return _logger;
   }
 
+  /**
+   * @fn static void LoggerServiceLocator::clean()
+   * @brief ロガーをクリーンアップします。
+   *
+   * ロガーのクリーンアップ処理を行い、メモリを解放します。
+   */
   static void clean() {
     _logger->trace("Logger cleaned");
     if (_logger != NULL) {

--- a/pkg/infra/logger/ConsoleLogger.hpp
+++ b/pkg/infra/logger/ConsoleLogger.hpp
@@ -20,6 +20,11 @@ public:
   void warning(std::string msg) { std::cout << "\e[33m[warning]: " << msg << "\e[m" << std::endl; }
 
   void error(std::string msg) { std::cout << "\e[31m[error]: " << msg << "\e[m" << std::endl; }
+
+  void fatal(std::string msg) {
+    std::cout << "\e[41m[fatal]: " << msg << "\e[m" << std::endl;
+    throw std::runtime_error(msg);
+  }
 };
 
 #endif /* CONSOLELOGGER_HPP */

--- a/pkg/infra/logger/FileLogger.hpp
+++ b/pkg/infra/logger/FileLogger.hpp
@@ -56,6 +56,13 @@ public:
     }
   }
 
+  void fatal(std::string msg) {
+    if (this->_ofile.is_open()) {
+      this->_ofile << this->getTime() << " [fatal]: " << msg << std::endl;
+    }
+    throw std::runtime_error(msg);
+  }
+
 private:
   std::fstream _ofile;
 

--- a/pkg/infra/logger/ILogger.hpp
+++ b/pkg/infra/logger/ILogger.hpp
@@ -6,15 +6,66 @@
 
 #include "infra/logger/LogLevel.hpp"
 
+/**
+ * @class ILogger
+ * @brief ログ出力のためのインターフェースクラス
+ *
+ * ILoggerは、異なるログレベルでメッセージを出力するための仮想関数を提供します。
+ * このクラスを継承して、具体的なログ出力方法を実装します。
+ *
+ * @note このクラスはインターフェースとして機能するため、直接インスタンス化することはできません。
+ */
 class ILogger {
 public:
+  /**
+ * @brief デストラクタ
+ *
+ * 派生クラスでリソースを解放するためにオーバーライドされることを想定しています。
+ */
   virtual ~ILogger(){};
+  /**
+ * @brief トレースレベルのログメッセージを出力します。
+ * @param msg ログメッセージ
+ */
   virtual void trace(std::string msg) = 0;
+
+  /**
+ * @brief デバッグレベルのログメッセージを出力します。
+ * @param msg ログメッセージ
+ */
   virtual void debug(std::string msg) = 0;
+
+  /**
+ * @brief 情報レベルのログメッセージを出力します。
+ * @param msg ログメッセージ
+ */
   virtual void info(std::string msg) = 0;
+
+  /**
+ * @brief 警告レベルのログメッセージを出力します。
+ * @param msg ログメッセージ
+ */
   virtual void warning(std::string msg) = 0;
+
+  /**
+ * @brief エラーレベルのログメッセージを出力します。
+ * @param msg ログメッセージ
+ */
   virtual void error(std::string msg) = 0;
 
+  /**
+ * @brief 致命的なエラーレベルのログメッセージを出力し、std::runtime_errorをスローします。
+ * @param msg ログメッセージ
+ */
+  virtual void fatal(std::string msg) = 0;
+
+  /**
+ * @brief 指定されたログレベルでメッセージを出力します。
+ * @param level ログレベル
+ * @param msg ログメッセージ
+ *
+ * @details ログレベルに応じて適切な仮想関数を呼び出します。
+ */
   virtual void log(LogLevel level, const std::string &msg) {
     switch (level) {
     case TRACE:
@@ -31,6 +82,9 @@ public:
       break;
     case ERROR:
       this->error(msg);
+      break;
+    case FATAL:
+      this->fatal(msg);
       break;
     }
   }

--- a/pkg/infra/logger/LogLevel.hpp
+++ b/pkg/infra/logger/LogLevel.hpp
@@ -1,6 +1,6 @@
 #ifndef LOGLEVEL_HPP
 #define LOGLEVEL_HPP
 
-enum LogLevel { TRACE, DEBUG, INFO, WARNING, ERROR };
+enum LogLevel { TRACE, DEBUG, INFO, WARNING, ERROR, FATAL };
 
 #endif /* LOGLEVEL_HPP */

--- a/pkg/infra/logger/MultiLogger.hpp
+++ b/pkg/infra/logger/MultiLogger.hpp
@@ -55,6 +55,18 @@ public:
     }
   }
 
+  void fatal(std::string msg) {
+    std::vector<ILogger *>::iterator it;
+    for (it = _loggers.begin(); it != _loggers.end(); it++) {
+      try {
+        (*it)->fatal(msg);
+      } catch (...) {
+        // ignore
+      }
+    }
+    throw std::runtime_error(msg);
+  }
+
   std::size_t size() { return _loggers.size(); }
 
   void clear() {

--- a/pkg/infra/logger/StreamLogger.hpp
+++ b/pkg/infra/logger/StreamLogger.hpp
@@ -5,14 +5,45 @@
 #include "infra/logger/LogLevel.hpp"
 #include "infra/logger/LogStream.hpp"
 
+/**
+ * @class StreamLogger
+ * @brief ログ出力をストリーム形式で行うためのクラス
+ *
+ * このクラスは、ILogger インターフェースを使用してログメッセージを
+ * ストリーム形式で出力するための機能を提供します。
+ */
 class StreamLogger {
 public:
+  /**
+   * @brief コンストラクタ
+   * @param logger ILogger インターフェースを実装したロガーオブジェクト
+   */
   StreamLogger(ILogger *logger) : _logger(logger) {}
   ~StreamLogger() {}
+  /**
+   * @brief TRACE レベルのログストリームを取得
+   * @return TRACE レベルの LogStream オブジェクト
+   */
   LogStream tracess(void) { return LogStream(_logger, TRACE); }
+  /**
+   * @brief DEBUG レベルのログストリームを取得
+   * @return DEBUG レベルの LogStream オブジェクト
+   */
   LogStream debugss(void) { return LogStream(_logger, DEBUG); }
+  /**
+   * @brief INFO レベルのログストリームを取得
+   * @return INFO レベルの LogStream オブジェクト
+   */
   LogStream infoss(void) { return LogStream(_logger, INFO); }
+  /**
+   * @brief WARNING レベルのログストリームを取得
+   * @return WARNING レベルの LogStream オブジェクト
+   */
   LogStream warningss(void) { return LogStream(_logger, WARNING); }
+  /**
+   * @brief ERROR レベルのログストリームを取得
+   * @return ERROR レベルの LogStream オブジェクト
+   */
   LogStream errorss(void) { return LogStream(_logger, ERROR); }
 
 private:

--- a/pkg/tests/infra/logger/test_ConsoleLogger.cpp
+++ b/pkg/tests/infra/logger/test_ConsoleLogger.cpp
@@ -47,6 +47,14 @@ TEST_F(ConsoleLoggerTest, ErrorLevel) {
   EXPECT_EQ(output, "\e[31m[error]: Error message\e[m\n");
 }
 
+TEST_F(ConsoleLoggerTest, FatalLevel) {
+  ConsoleLogger logger;
+  testing::internal::CaptureStdout();
+  EXPECT_THROW(logger.fatal("Fatal message"), std::runtime_error);
+  std::string output = testing::internal::GetCapturedStdout();
+  EXPECT_EQ(output, "\e[41m[fatal]: Fatal message\e[m\n");
+}
+
 TEST_F(ConsoleLoggerTest, TraceLevelSS) {
   ConsoleLogger logger;
   testing::internal::CaptureStdout();

--- a/pkg/tests/infra/logger/test_FileLogger.cpp
+++ b/pkg/tests/infra/logger/test_FileLogger.cpp
@@ -99,6 +99,21 @@ TEST_F(FileLoggerTest, ErrorLog) {
   ifile.close();
 }
 
+TEST_F(FileLoggerTest, FatalLog) {
+  std::string logFile = "test_fatal.log";
+  FileLogger logger(logFile);
+  EXPECT_THROW(logger.fatal("This is a fatal message"), std::runtime_error);
+
+  std::ifstream ifile(logFile);
+  ASSERT_TRUE(ifile.is_open());
+
+  std::string line;
+  std::getline(ifile, line);
+  ASSERT_NE(line.find("[fatal]: This is a fatal message"), std::string::npos);
+
+  ifile.close();
+}
+
 TEST_F(FileLoggerTest, MultipleMessages) {
   std::string logFile = "test_multiple.log";
   FileLogger logger(logFile);

--- a/pkg/tests/infra/logger/test_MultiLogger.cpp
+++ b/pkg/tests/infra/logger/test_MultiLogger.cpp
@@ -11,6 +11,7 @@ public:
   MOCK_METHOD(void, info, (std::string msg));
   MOCK_METHOD(void, warning, (std::string msg));
   MOCK_METHOD(void, error, (std::string msg));
+  MOCK_METHOD(void, fatal, (std::string msg));
   MOCK_METHOD(void, log, (LogLevel level, const std::string &msg));
 };
 
@@ -44,4 +45,18 @@ TEST_F(MultiLoggerTest, DualLoggers) {
   EXPECT_CALL(*mockLogger1, info("Info message")).Times(1);
   EXPECT_CALL(*mockLogger2, info("Info message")).Times(1);
   logger.info("Info message");
+}
+
+TEST_F(MultiLoggerTest, MultipleFatalLoggers) {
+  MultiLogger logger;
+  auto mockLogger1 = new MockLogger();
+  auto mockLogger2 = new MockLogger();
+  logger.addLogger(mockLogger1);
+  logger.addLogger(mockLogger2);
+
+  EXPECT_CALL(*mockLogger1, fatal("Fatal message"))
+      .WillOnce(testing::Throw(std::runtime_error("Fatal message1")));
+  EXPECT_CALL(*mockLogger2, fatal("Fatal message"))
+      .WillOnce(testing::Throw(std::runtime_error("Fatal message2")));
+  EXPECT_THROW(logger.fatal("Fatal message"), std::runtime_error);
 }


### PR DESCRIPTION
コンソール出力はこんな感じ
![image](https://github.com/user-attachments/assets/cbf4fedf-d963-4101-b407-34783964a3cb)

デストラクタで例外をスロー出来ない都合上、
```c++
logger->fatalss() << "error";
```
とかは出来ない。というかfatalss() は実装してない