### PR TITLE
patch: .gitignoreに*.infoを追加し、Makefileにカバレッジコマンドを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.lo
 *.o
 *.obj
+*.info
 
 # Precompiled Headers
 *.gch

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,9 @@ test: build
 .PHONY: locust
 locust: debug
 	locust -f tools/locustfile.py
+
+.PHONY: cov
+cov: build
+	lcov --capture --directory . --output-file coverage.info
+	lcov --remove coverage.info '/usr/*' --output-file coverage.info # filter system-files
+	lcov --list coverage.info # debug info


### PR DESCRIPTION
make covでコードカバレッジを表示できる