### PR TITLE
update: Privmsgコマンドを暫定的に実装

### DIFF
--- a/pkg/application/commands/Privmsg.cpp
+++ b/pkg/application/commands/Privmsg.cpp
@@ -1,0 +1,107 @@
+#include "application/commands/Privmsg.hpp"
+
+Privmsg::Privmsg(IMessageAggregateRoot *msg, IClientAggregateRoot *client)
+    : ACommands(msg, client) {
+  this->_channelDB = &InmemoryChannelDBServiceLocator::get();
+  this->_clientDB = &InmemoryClientDBServiceLocator::get();
+  this->_logger = LoggerServiceLocator::get();
+  this->_conf = &ConfigsServiceLocator::get();
+  this->_socketHandler = &SocketHandlerServiceLocator::get();
+}
+
+SendMsgDTO Privmsg::execute() {
+  IMessageAggregateRoot *msg = this->getMessage();
+  IClientAggregateRoot *client = this->getClient();
+
+  MessageStreamVector streams;
+  if (msg->getParams().size() < 2) {
+    MessageStream stream = MessageService::generateMessageStream(this->_socketHandler, client);
+
+    stream << Message(
+        ConfigsServiceLocator::get().getConfigs().Global.Name,
+        MessageConstants::ResponseCode::ERR_NEEDMOREPARAMS,
+        client->getNickName() + " PRIVMSG :Not enough parameters");
+    streams.push_back(stream);
+    this->_logger->debugss() << "[PRIVMSG]: Not enough parameters (" << client->getSocketFd()
+                             << ")";
+    return SendMsgDTO(1, streams);
+  }
+
+  const std::string &target = msg->getParams()[0];
+  const std::string &message = msg->getParams()[1];
+  if (this->_conf->getConfigs().Options.AllowedChannelTypes.find(target[0]) !=
+      std::string::npos) { // 引数が"#"もしくは"&"で始まる場合
+    return _handleChannelMessage(target, message);
+  } else {
+    return _handleUserMessage(target, message);
+  }
+}
+
+SendMsgDTO
+Privmsg::_handleChannelMessage(const std::string &channelName, const std::string &message) {
+  MessageStreamVector streams;
+  IClientAggregateRoot *client = this->getClient();
+
+  IChannelAggregateRoot *channel = this->_channelDB->get(channelName);
+  if (channel == NULL) {
+    MessageStream stream = MessageService::generateMessageStream(this->_socketHandler, client);
+    stream << Message(
+        ConfigsServiceLocator::get().getConfigs().Global.Name,
+        MessageConstants::ResponseCode::ERR_NOSUCHCHANNEL,
+        client->getNickName() + " " + channelName + " :No such channel");
+    streams.push_back(stream);
+    this->_logger->debugss() << "[PRIVMSG]: No such channel (" << client->getSocketFd() << ")";
+    return SendMsgDTO(1, streams);
+  }
+  // クライアントがチャンネルのメンバーである
+  if (!channel->getListConnects().isClientInList(client->getNickName())) {
+    MessageStream stream = MessageService::generateMessageStream(this->_socketHandler, client);
+    stream << Message(
+        ConfigsServiceLocator::get().getConfigs().Global.Name,
+        MessageConstants::ResponseCode::ERR_CANNOTSENDTOCHAN,
+        client->getNickName() + " " + channelName + " :Cannot send to channel");
+    streams.push_back(stream);
+    this->_logger->debugss() << "[PRIVMSG]: Cannot send to channel (" << client->getSocketFd()
+                             << ")";
+    return SendMsgDTO(1, streams);
+  }
+  // メッセージ送信
+  std::stringstream ss;
+  ss << Message(
+      client->getNickName() + "!" + client->getUserName() + "@" + client->getAddress(),
+      MessageConstants::PRIVMSG, channelName + " :" + message);
+  MessageStreamVector channelStreams = MessageService::generateMessageToChannel(
+      this->_socketHandler, client, this->_clientDB, channel, ss.str());
+  streams.insert(streams.end(), channelStreams.begin(), channelStreams.end());
+  this->_logger->debugss() << "[PRIVMSG]: Message sent to channel " << channelName << " ("
+                           << client->getSocketFd() << ")";
+  return SendMsgDTO(0, streams);
+}
+
+SendMsgDTO Privmsg::_handleUserMessage(const std::string &nickname, const std::string &message) {
+  MessageStreamVector streams;
+  IClientAggregateRoot *client = this->getClient();
+
+  IClientAggregateRoot *targetClient = this->_clientDB->getById(nickname);
+  if (!targetClient) {
+    MessageStream stream = MessageService::generateMessageStream(this->_socketHandler, client);
+    stream << Message(
+        ConfigsServiceLocator::get().getConfigs().Global.Name,
+        MessageConstants::ResponseCode::ERR_NOSUCHNICK,
+        client->getNickName() + " " + nickname + " :No such nick/channel");
+    streams.push_back(stream);
+    this->_logger->debugss() << "[PRIVMSG]: No such nick (" << client->getSocketFd() << ")";
+    return SendMsgDTO(1, streams);
+  }
+
+  // メッセージを作成して送信
+  MessageStream stream = MessageService::generateMessageStream(this->_socketHandler, targetClient);
+  stream << Message(
+      client->getNickName() + "!" + client->getUserName() + "@" + client->getAddress(),
+      MessageConstants::PRIVMSG, nickname + " :" + message);
+  streams.push_back(stream);
+
+  this->_logger->debugss() << "[PRIVMSG]: Message sent to " << nickname << " ("
+                           << client->getSocketFd() << ")";
+  return SendMsgDTO(0, streams);
+}

--- a/pkg/application/commands/Privmsg.hpp
+++ b/pkg/application/commands/Privmsg.hpp
@@ -1,0 +1,31 @@
+#ifndef PRIVMSG_HPP
+#define PRIVMSG_HPP
+
+#include "application/commands/ACommands.hpp"
+#include "application/serviceLocator/ConfigsServiceLocator.hpp"
+#include "application/serviceLocator/InmemoryChannelDBServiceLocator.hpp"
+#include "application/serviceLocator/InmemoryClientDBServiceLocator.hpp"
+#include "application/serviceLocator/LoggerServiceLocator.hpp"
+#include "application/serviceLocator/SocketHandlerServiceLocator.hpp"
+#include "domain/channel/Channel.hpp"
+#include "domain/client/IClientAggregateRoot.hpp"
+#include "domain/message/IMessageAggregateRoot.hpp"
+#include "domain/message/MessageService.hpp"
+
+class Privmsg : public ACommands {
+public:
+  Privmsg(IMessageAggregateRoot *msg, IClientAggregateRoot *client);
+  SendMsgDTO execute();
+
+private:
+  SendMsgDTO _handleChannelMessage(const std::string &channelName, const std::string &message);
+  SendMsgDTO _handleUserMessage(const std::string &nickname, const std::string &message);
+
+  InmemoryChannelDatabase *_channelDB;
+  InmemoryClientDatabase *_clientDB;
+  MultiLogger *_logger;
+  ConfigsLoader *_conf;
+  ISocketHandler *_socketHandler;
+};
+
+#endif /* PRIVMSG_HPP */

--- a/pkg/application/useCases/RunCommandsUseCase.cpp
+++ b/pkg/application/useCases/RunCommandsUseCase.cpp
@@ -28,7 +28,7 @@ SendMsgDTO RunCommandsUseCase::execute(RecievedMsgDTO &recieved) {
     dto = Join(&clientMsg, client).execute();
     break;
   case (MessageConstants::PRIVMSG):
-    // dto = ..
+    dto = Privmsg(&clientMsg, client).execute();
     break;
   case (MessageConstants::KICK):
     // dto = ..

--- a/pkg/application/useCases/RunCommandsUseCase.hpp
+++ b/pkg/application/useCases/RunCommandsUseCase.hpp
@@ -5,6 +5,8 @@
 #include "application/commands/Mode.hpp"
 #include "application/commands/Nick.hpp"
 #include "application/commands/Pass.hpp"
+#include "application/commands/Privmsg.hpp"
+
 #include "application/dto/RecievedMsgDTO.hpp"
 #include "application/dto/SendMsgDTO.hpp"
 #include "application/serviceLocator/LoggerServiceLocator.hpp"

--- a/pkg/domain/message/Message.cpp
+++ b/pkg/domain/message/Message.cpp
@@ -227,7 +227,7 @@ int Message::parseParams(std::vector<std::string> &params, const std::string par
         remaining.resize(remaining.size() - 1);
       }
       word += remaining;
-      params.push_back(word);
+      params.push_back(word.substr(1));
       break;
     }
     params.push_back(word);

--- a/pkg/domain/message/MessageConstants.hpp
+++ b/pkg/domain/message/MessageConstants.hpp
@@ -27,12 +27,12 @@ const int RPL_NAMREPLY = 353;
 const int RPL_ENDOFNAMES = 366;
 const int ERR_NEEDMOREPARAMS = 461;
 const int ERR_ALREADYREGISTRED = 462;
-
 const int ERR_NOSUCHNICK = 401;
 const int RPL_CHANNELMODEIS = 324;
 const int RPL_CREATIONTIME_MSG = 329;
 const int ERR_CHANOPRIVSNEEDED = 482;
 const int ERR_NOSUCHCHANNEL = 403;
+const int ERR_CANNOTSENDTOCHAN = 404;
 } // namespace ResponseCode
 } // namespace MessageConstants
 

--- a/pkg/tests/CMakeLists.txt
+++ b/pkg/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(DomainTest
  ${CMAKE_CURRENT_SOURCE_DIR}/domain/message/test_Message.cpp
  ${CMAKE_CURRENT_SOURCE_DIR}/domain/message/test_MessageParser.cpp
  ${CMAKE_CURRENT_SOURCE_DIR}/domain/message/test_MessageParserPrefix.cpp
+ ${CMAKE_CURRENT_SOURCE_DIR}/domain/message/test_MessageParseParams.cpp
  ${CMAKE_CURRENT_SOURCE_DIR}/domain/shared/test_JenkinsHash.cpp
  ${CMAKE_CURRENT_SOURCE_DIR}/domain/shared/test_RFCChannelHash.cpp
 )

--- a/pkg/tests/domain/message/test_Message.cpp
+++ b/pkg/tests/domain/message/test_Message.cpp
@@ -80,7 +80,7 @@ TEST(MessageTest, AssignmentOperatorWithNumericResponse) {
   EXPECT_EQ(assigned.getNumericResponse(), "404");
   EXPECT_EQ(assigned.getParams().size(), 2);
   EXPECT_EQ(assigned.getParams()[0], "nick");
-  EXPECT_EQ(assigned.getParams()[1], ":No such nick/channel");
+  EXPECT_EQ(assigned.getParams()[1], "No such nick/channel");
 }
 
 TEST(MessageTest, AssignmentOperatorSelfAssignment) {
@@ -91,7 +91,7 @@ TEST(MessageTest, AssignmentOperatorSelfAssignment) {
   EXPECT_EQ(message.getCommand(), MessageConstants::PRIVMSG);
   EXPECT_EQ(message.getParams().size(), 2);
   EXPECT_EQ(message.getParams()[0], "target");
-  EXPECT_EQ(message.getParams()[1], ":Hello world!");
+  EXPECT_EQ(message.getParams()[1], "Hello world!");
 }
 
 TEST(MessageTest, AssignmentOperatorEmptyMessage) {

--- a/pkg/tests/domain/message/test_MessageParseParams.cpp
+++ b/pkg/tests/domain/message/test_MessageParseParams.cpp
@@ -1,0 +1,223 @@
+#include "domain/message/Message.hpp"
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+// Test structure to hold test cases
+struct ParamTestCase {
+  std::string paramStr;
+  std::vector<std::string> expectedParams;
+  std::string description;
+};
+
+class MessageParseParamsTest : public ::testing::TestWithParam<ParamTestCase> {};
+
+TEST_P(MessageParseParamsTest, ParseParams) {
+  auto testCase = GetParam();
+
+  std::vector<std::string> params;
+  int result = Message::parseParams(params, testCase.paramStr);
+
+  EXPECT_EQ(result, 0) << "Failed on test case: " << testCase.description;
+  EXPECT_EQ(params.size(), testCase.expectedParams.size())
+      << "Param count mismatch on test case: " << testCase.description;
+
+  for (size_t i = 0; i < params.size() && i < testCase.expectedParams.size(); ++i) {
+    EXPECT_EQ(params[i], testCase.expectedParams[i])
+        << "Param at index " << i << " mismatch on test case: " << testCase.description;
+  }
+}
+
+// Individual test cases for specific scenarios
+TEST(MessageParseParamsTest, EmptyString) {
+  std::vector<std::string> params;
+  std::string paramStr = "";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 0);
+}
+
+TEST(MessageParseParamsTest, SingleParam) {
+  std::vector<std::string> params;
+  std::string paramStr = "param1";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 1);
+  EXPECT_EQ(params[0], "param1");
+}
+
+TEST(MessageParseParamsTest, MultipleParams) {
+  std::vector<std::string> params;
+  std::string paramStr = "param1 param2 param3";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 3);
+  EXPECT_EQ(params[0], "param1");
+  EXPECT_EQ(params[1], "param2");
+  EXPECT_EQ(params[2], "param3");
+}
+
+TEST(MessageParseParamsTest, TrailingParam) {
+  std::vector<std::string> params;
+  std::string paramStr = "param1 param2 :This is a trailing parameter";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 3);
+  EXPECT_EQ(params[0], "param1");
+  EXPECT_EQ(params[1], "param2");
+  EXPECT_EQ(params[2], "This is a trailing parameter");
+}
+
+TEST(MessageParseParamsTest, OnlyTrailingParam) {
+  std::vector<std::string> params;
+  std::string paramStr = ":This is only a trailing parameter";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 1);
+  EXPECT_EQ(params[0], "This is only a trailing parameter");
+}
+
+TEST(MessageParseParamsTest, TrailingParamWithColon) {
+  std::vector<std::string> params;
+  std::string paramStr = "param1 :This is a: trailing parameter with: colons";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "param1");
+  EXPECT_EQ(params[1], "This is a: trailing parameter with: colons");
+}
+
+TEST(MessageParseParamsTest, ParamsWithCRLF) {
+  std::vector<std::string> params;
+  std::string paramStr = "param1 param2\r\n";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "param1");
+  EXPECT_EQ(params[1], "param2");
+}
+
+TEST(MessageParseParamsTest, TrailingParamWithCRLF) {
+  std::vector<std::string> params;
+  std::string paramStr = "param1 :Trailing parameter\r\n";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "param1");
+  EXPECT_EQ(params[1], "Trailing parameter");
+}
+
+TEST(MessageParseParamsTest, ClearsExistingParams) {
+  std::vector<std::string> params = {"existing1", "existing2"};
+  std::string paramStr = "param1 param2";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "param1");
+  EXPECT_EQ(params[1], "param2");
+}
+
+TEST(MessageParseParamsTest, SpecialCharacters) {
+  std::vector<std::string> params;
+  std::string paramStr = "param1 param-2 param_3 :Special chars: !@#$%^&*()";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 4);
+  EXPECT_EQ(params[0], "param1");
+  EXPECT_EQ(params[1], "param-2");
+  EXPECT_EQ(params[2], "param_3");
+  EXPECT_EQ(params[3], "Special chars: !@#$%^&*()");
+}
+
+TEST(MessageParseParamsTest, EmptyTrailingParam) {
+  std::vector<std::string> params;
+  std::string paramStr = "param1 param2 :";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 3);
+  EXPECT_EQ(params[0], "param1");
+  EXPECT_EQ(params[1], "param2");
+  EXPECT_EQ(params[2], "");
+}
+
+TEST(MessageParseParamsTest, WhitespaceHandling) {
+  std::vector<std::string> params;
+  std::string paramStr = "  param1   param2  param3  ";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 3);
+  EXPECT_EQ(params[0], "param1");
+  EXPECT_EQ(params[1], "param2");
+  EXPECT_EQ(params[2], "param3");
+}
+
+TEST(MessageParseParamsTest, WhitespaceInTrailingParam) {
+  std::vector<std::string> params;
+  std::string paramStr = "param1 :  Trailing with   multiple   spaces  ";
+
+  int result = Message::parseParams(params, paramStr);
+
+  EXPECT_EQ(result, 0);
+  EXPECT_EQ(params.size(), 2);
+  EXPECT_EQ(params[0], "param1");
+  EXPECT_EQ(params[1], "  Trailing with   multiple   spaces  ");
+}
+
+// Parameterized test cases
+INSTANTIATE_TEST_SUITE_P(
+    MessageParseParamsTests,
+    MessageParseParamsTest,
+    ::testing::Values(
+        ParamTestCase{"", {}, "Empty string"},
+        ParamTestCase{"param1", {"param1"}, "Single parameter"},
+        ParamTestCase{
+            "param1 param2 param3", {"param1", "param2", "param3"}, "Multiple parameters"},
+        ParamTestCase{
+            "param1 param2 :Trailing param",
+            {"param1", "param2", "Trailing param"},
+            "With trailing parameter"},
+        ParamTestCase{":Only trailing", {"Only trailing"}, "Only trailing parameter"},
+        ParamTestCase{"param1 param2\r\n", {"param1", "param2"}, "With CRLF"},
+        ParamTestCase{
+            "param1 :Trailing with CRLF\r\n",
+            {"param1", "Trailing with CRLF"},
+            "Trailing parameter with CRLF"},
+        ParamTestCase{"#channel +o user", {"#channel", "+o", "user"}, "Channel mode parameters"},
+        ParamTestCase{
+            "#channel :Welcome to IRC!", {"#channel", "Welcome to IRC!"}, "Channel topic"},
+        ParamTestCase{
+            "user :Ping timeout: 180 seconds",
+            {"user", "Ping timeout: 180 seconds"},
+            "Quit message"},
+        ParamTestCase{
+            "#channel user :You have been kicked",
+            {"#channel", "user", "You have been kicked"},
+            "Kick message"},
+        ParamTestCase{
+            "user #channel :You are invited",
+            {"user", "#channel", "You are invited"},
+            "Invite message"}));


### PR DESCRIPTION
マスク形式：$mask、#mask（サーバー/ホストマスク）には対応せず

![image](https://github.com/user-attachments/assets/8d94eaa3-31b4-4934-8f3b-95d0d3699710)

細かな出力フォーマットの確認は今後行う
