### PR TITLE
feat: docker composeでft_ircを起動できるようにした。

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,9 @@ name: Docker image Build and Push
 
 on:
   push:
-    tags:
-      - "v*.*"
+    branches: ["main"]
+  pull_request:
+    branches: ["ci/**"]
   workflow_dispatch:
 
 jobs:
@@ -28,6 +29,8 @@ jobs:
         password: ${{ secrets.PUSH_KEY }}
     - name: Build the Docker image
       run: |
-        docker build --target release --file Dockerfile --tag $IMAGE_NAME:${{ steps.var.outputs.SHORT_SHA }} .
+        docker build --target release --file Dockerfile --tag $IMAGE_NAME:${{ steps.var.outputs.SHORT_SHA }} --tag $IMAGE_NAME:latest .
     - name: Push the Docker image
-      run: docker push $IMAGE_NAME:${{ steps.var.outputs.SHORT_SHA }}
+      run: |
+        docker push $IMAGE_NAME:${{ steps.var.outputs.SHORT_SHA }}
+        docker push $IMAGE_NAME:latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,12 +20,7 @@
   "C/C++ Include Guard.Path Skip": 0,
   "C/C++ Include Guard.Remove Extension": false,
   "C/C++ Include Guard.Spaces After Endif": 1,
-  "C/C++ Include Guard.Header Extensions": [
-    ".h",
-    ".hpp",
-    ".h++",
-    ".hh"
-  ],
+  "C/C++ Include Guard.Header Extensions": [".h", ".hpp", ".h++", ".hh"],
   "files.associations": {
     "iosfwd": "cpp",
     "variant": "cpp",
@@ -96,5 +91,9 @@
     "numbers": "cpp",
     "semaphore": "cpp"
   },
-
+  "python.testing.pytestArgs": [
+    "tools"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY . /repo
 
 RUN make
 
-FROM debian:12.9-slim AS release
+FROM gcr.io/distroless/cc-debian12 AS release
 ENV DEBIAN_FRONTEND=noninteractive
 
 COPY --from=build /repo/ft_irc /usr/local/bin/ft_irc

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ TESTS =
 TESTS += $(shell find $(BASE_PKG_DIR)/tests -name '*.h' -o -name '*.hpp' -o -name '*.c' -o -name '*.cpp')
 
 CXX := c++
-CFLAGS := -Wall -Wextra -Werror -std=c++98 -MMD -MP -I$(BASE_PKG_DIR)
+CFLAGS := -Wall -Wextra -Werror -std=c++98 -MMD -MP -I$(BASE_PKG_DIR) -O3
 LFALGS := 
 DFLAGS := -fdiagnostics-color=always -g3 -fsanitize=address
 

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,1 +1,0 @@
-ngircd.conf

--- a/config/ngircd.conf
+++ b/config/ngircd.conf
@@ -1,0 +1,389 @@
+#
+# This is a sample configuration file for the ngIRCd IRC daemon, which must
+# be customized to the local preferences and needs.
+#
+# Comments are started with "#" or ";".
+#
+# A lot of configuration options in this file start with a ";". You have
+# to remove the ";" in front of each variable to actually set a value!
+# The disabled variables are shown with example values for completeness only
+# and the daemon is using compiled-in default settings.
+#
+# Use "ngircd --configtest" (see manual page ngircd(8)) to validate that the
+# server interprets the configuration file as expected!
+#
+# Please see ngircd.conf(5) for a complete list of configuration options
+# and their descriptions.
+#
+
+[Global]
+	# The [Global] section of this file is used to define the main
+	# configuration of the server, like the server name and the ports
+	# on which the server should be listening.
+	# These settings depend on your personal preferences, so you should
+	# make sure that they correspond to your installation and setup!
+
+	# Server name in the IRC network, must contain at least one dot
+	# (".") and be unique in the IRC network. Required!
+	Name = irc.example.net
+
+	# Information about the server and the administrator, used by the
+	# ADMIN command. Not required by server but by RFC!
+	;AdminInfo1 = Description
+	;AdminInfo2 = Location
+	;AdminEMail = admin@irc.server
+
+	# Text file which contains the ngIRCd help text. This file is required
+	# to display help texts when using the "HELP <cmd>" command.
+	;HelpFile = /usr/share/doc/ngircd/Commands.txt
+
+	# Info text of the server. This will be shown by WHOIS and
+	# LINKS requests for example.
+	Info = Server Info Text
+
+	# Comma separated list of IP addresses on which the server should
+	# listen. Default values are:
+	# "0.0.0.0" or (if compiled with IPv6 support) "::,0.0.0.0"
+	# so the server listens on all IP addresses of the system by default.
+	;Listen = 127.0.0.1,192.168.0.1
+
+	# Text file with the "message of the day" (MOTD). This message will
+	# be shown to all users connecting to the server:
+	MotdFile = /etc/ngircd/ngircd.motd
+
+	# A simple Phrase (<256 chars) if you don't want to use a motd file.
+	;MotdPhrase = "Hello world!"
+
+	# The name of the IRC network to which this server belongs. This name
+	# is optional, should only contain ASCII characters, and can't contain
+	# spaces. It is only used to inform clients. The default is empty,
+	# so no network name is announced to clients.
+	;Network = aIRCnetwork
+
+	# Global password for all users needed to connect to the server.
+	# (Default: not set)
+	Password = password
+
+	# This tells ngIRCd to write its current process ID to a file.
+	# Note that the pidfile is written AFTER chroot and switching the
+	# user ID, e.g. the directory the pidfile resides in must be
+	# writable by the ngIRCd user and exist in the chroot directory.
+	PidFile = /var/run/ngircd/ngircd.pid
+
+	# Ports on which the server should listen. There may be more than
+	# one port, separated with ",". (Default: 6667)
+	;Ports = 6667, 6668, 6669
+
+	# Group ID under which the ngIRCd should run; you can use the name
+	# of the group or the numerical ID. ATTENTION: For this to work the
+	# server must have been started with root privileges!
+	ServerGID = abc
+
+	# User ID under which the server should run; you can use the name
+	# of the user or the numerical ID. ATTENTION: For this to work the
+	# server must have been started with root privileges! In addition,
+	# the configuration and MOTD files must be readable by this user,
+	# otherwise RESTART and REHASH won't work!
+	ServerUID = abc
+
+[Limits]
+	# Define some limits and timeouts for this ngIRCd instance. Default
+	# values should be safe, but it is wise to double-check :-)
+
+	# The server tries every <ConnectRetry> seconds to establish a link
+	# to not yet (or no longer) connected servers.
+	ConnectRetry = 60
+
+	# Number of seconds after which the whole daemon should shutdown when
+	# no connections are left active after handling at least one client
+	# (0: never, which is the default).
+	# This can be useful for testing or when ngIRCd is started using
+	# "socket activation" with systemd(8), for example.
+	;IdleTimeout = 0
+
+	# Maximum number of simultaneous in- and outbound connections the
+	# server is allowed to accept (0: unlimited):
+	MaxConnections = 0
+
+	# Maximum number of simultaneous connections from a single IP address
+	# the server will accept (0: unlimited):
+	MaxConnectionsIP = 5
+
+	# Maximum number of channels a user can be member of (0: no limit):
+	MaxJoins = 50
+
+	# Maximum length of an user nickname (Default: 9, as in RFC 2812).
+	# Please note that all servers in an IRC network MUST use the same
+	# maximum nickname length!
+	;MaxNickLength = 9
+
+	# Maximum number of channels returned in response to a /list
+	# command (0: unlimited):
+	;MaxListSize = 100
+
+	# After <PingTimeout> seconds of inactivity the server will send a
+	# PING to the peer to test whether it is alive or not.
+	PingTimeout = 300
+
+	# If a client fails to answer a PING with a PONG within <PongTimeout>
+	# seconds, it will be disconnected by the server.
+	PongTimeout = 300
+
+[Options]
+	# Optional features and configuration options to further tweak the
+	# behavior of ngIRCd. If you want to get started quickly, you most
+	# probably don't have to make changes here -- they are all optional.
+
+	# List of allowed channel types (channel prefixes) for newly created
+	# channels on the local server. By default, all supported channel
+	# types are allowed. Set this variable to the empty string to disallow
+	# creation of new channels by local clients at all.
+	;AllowedChannelTypes = #&+
+
+	# Are remote IRC operators allowed to control this server, e.g.
+	# use commands like CONNECT, SQUIT, DIE, ...?
+	;AllowRemoteOper = no
+
+	# A directory to chroot in when everything is initialized. It
+	# doesn't need to be populated if ngIRCd is compiled as a static
+	# binary. By default ngIRCd won't use the chroot() feature.
+	# ATTENTION: For this to work the server must have been started
+	# with root privileges!
+	;ChrootDir = /var/empty
+
+	# Set this hostname for every client instead of the real one.
+	# Use %x to add the hashed value of the original hostname.
+	;CloakHost = cloaked.host
+
+	# Use this hostname for hostname cloaking on clients that have the
+	# user mode "+x" set, instead of the name of the server.
+	# Use %x to add the hashed value of the original hostname.
+	;CloakHostModeX = cloaked.user
+
+	# The Salt for cloaked hostname hashing. When undefined a random
+	# hash is generated after each server start.
+	;CloakHostSalt = abcdefghijklmnopqrstuvwxyz
+
+	# Set every clients' user name to their nickname
+	;CloakUserToNick = yes
+
+	# Try to connect to other IRC servers using IPv4 and IPv6, if possible.
+	;ConnectIPv6 = yes
+	;ConnectIPv4 = yes
+
+	# Default user mode(s) to set on new local clients. Please note that
+	# only modes can be set that the client could set using regular MODE
+	# commands, you can't set "a" (away) for example! Default: none.
+	;DefaultUserModes = i
+
+	# Do DNS lookups when a client connects to the server.
+	;DNS = yes
+
+	# Do IDENT lookups if ngIRCd has been compiled with support for it.
+	# Users identified using IDENT are registered without the "~" character
+	# prepended to their user name.
+	;Ident = yes
+
+	# Directory containing configuration snippets (*.conf), that should
+	# be read in after parsing this configuration file.
+	;IncludeDir = /etc/ngircd/conf.d
+
+	# Enhance user privacy slightly (useful for IRC server on TOR or I2P)
+	# by censoring some information like idle time, logon time, etc.
+	;MorePrivacy = no
+
+	# Normally ngIRCd doesn't send any messages to a client until it is
+	# registered. Enable this option to let the daemon send "NOTICE *"
+	# messages to clients while connecting.
+	;NoticeBeforeRegistration = no
+
+	# Should IRC Operators be allowed to use the MODE command even if
+	# they are not(!) channel-operators?
+	OperCanUseMode = yes
+
+	# Should IRC Operators get AutoOp (+o) in persistent (+P) channels?
+	;OperChanPAutoOp = yes
+
+	# Mask IRC Operator mode requests as if they were coming from the
+	# server? (This is a compatibility hack for ircd-irc2 servers)
+	;OperServerMode = no
+
+	# Use PAM if ngIRCd has been compiled with support for it.
+	# Users identified using PAM are registered without the "~" character
+	# prepended to their user name.
+	PAM = no
+
+	# When PAM is enabled, all clients are required to be authenticated
+	# using PAM; connecting to the server without successful PAM
+	# authentication isn't possible.
+	# If this option is set, clients not sending a password are still
+	# allowed to connect: they won't become "identified" and keep the "~"
+	# character prepended to their supplied user name.
+	# Please note: To make some use of this behavior, it most probably
+	# isn't useful to enable "Ident", "PAM" and "PAMIsOptional" at the
+	# same time, because you wouldn't be able to distinguish between
+	# Ident'ified and PAM-authenticated users: both don't have a "~"
+	# character prepended to their respective user names!
+	;PAMIsOptional = no
+
+	# Let ngIRCd send an "authentication PING" when a new client connects,
+	# and register this client only after receiving the corresponding
+	# "PONG" reply.
+	;RequireAuthPing = no
+
+	# Silently drop all incoming CTCP requests.
+	;ScrubCTCP = no
+
+	# Syslog "facility" to which ngIRCd should send log messages.
+	# Possible values are system dependent, but most probably auth, daemon,
+	# user and local1 through local7 are possible values; see syslog(3).
+	# Default is "local5" for historical reasons, you probably want to
+	# change this to "daemon", for example.
+	;SyslogFacility = local1
+
+	# Password required for using the WEBIRC command used by some
+	# Web-to-IRC gateways. If not set/empty, the WEBIRC command can't
+	# be used. (Default: not set)
+	;WebircPassword = xyz
+
+;[SSL]
+	# SSL-related configuration options. Please note that this section
+	# is only available when ngIRCd is compiled with support for SSL!
+	# So don't forget to remove the ";" above if this is the case ...
+
+	# SSL Server Key Certificate
+	;CertFile = /etc/ngircd/ssl/server-cert.pem
+
+	# Select cipher suites allowed for SSL/TLS connections. This defaults
+	# to HIGH:!aNULL:@STRENGTH (OpenSSL) or SECURE128 (GnuTLS).
+	# See 'man 1ssl ciphers' (OpenSSL) or 'man 3 gnutls_priority_init'
+	# (GnuTLS) for details.
+	# For OpenSSL:
+	;CipherList = HIGH:!aNULL:@STRENGTH:!SSLv3
+	# For GnuTLS:
+	;CipherList = SECURE128:-VERS-SSL3.0
+
+	# Diffie-Hellman parameters
+	;DHFile = /etc/ngircd/ssl/dhparams.pem
+
+	# SSL Server Key
+	;KeyFile = /etc/ngircd/ssl/server-key.pem
+
+	# password to decrypt SSLKeyFile (OpenSSL only)
+	;KeyFilePassword = secret
+
+	# Additional Listen Ports that expect SSL/TLS encrypted connections
+	;Ports = 6697, 9999
+
+[Operator]
+	# [Operator] sections are used to define IRC Operators. There may be
+	# more than one [Operator] block, one for each local operator.
+
+	# ID of the operator (may be different of the nickname)
+	;Name = TheOper
+
+	# Password of the IRC operator
+	;Password = ThePwd
+
+	# Optional Mask from which /OPER will be accepted
+	;Mask = *!ident@somewhere.example.com
+
+[Operator]
+	# More [Operator] sections, if you like ...
+
+[Server]
+	# Other servers are configured in [Server] sections. If you
+	# configure a port for the connection, then this ngircd tries to
+	# connect to to the other server on the given port; if not it waits
+	# for the other server to connect.
+	# There may be more than one server block, one for each server.
+	#
+	# Server Groups:
+	# The ngIRCd allows "server groups": You can assign an "ID" to every
+	# server with which you want this ngIRCd to link. If a server of a
+	# group won't answer, the ngIRCd tries to connect to the next server
+	# in the given group. But the ngircd never tries to connect to two
+	# servers with the same group ID.
+
+	# IRC name of the remote server, must match the "Name" variable in
+	# the [Global] section of the other server (when using ngIRCd).
+	;Name = irc2.example.net
+
+	# Internet host name or IP address of the peer (only required when
+	# this server should establish the connection).
+	;Host = connect-to-host.example.net
+
+	# IP address to use as _source_ address for the connection. if
+	# unspecified, ngircd will let the operating system pick an address.
+	;Bind = 10.0.0.1
+
+	# Port of the server to which the ngIRCd should connect. If you
+	# assign no port the ngIRCd waits for incoming connections.
+	;Port = 6667
+
+	# Own password for the connection. This password has to be configured
+	# as "PeerPassword" on the other server.
+	;MyPassword = MySecret
+
+	# Foreign password for this connection. This password has to be
+	# configured as "MyPassword" on the other server.
+	;PeerPassword = PeerSecret
+
+	# Group of this server (optional)
+	;Group = 123
+
+	# Set the "Passive" option to "yes" if you don't want this ngIRCd to
+	# connect to the configured peer (same as leaving the "Port" variable
+	# empty). The advantage of this option is that you can actually
+	# configure a port an use the IRC command CONNECT more easily to
+	# manually connect this specific server later.
+	;Passive = no
+
+	# Connect to the remote server using TLS/SSL (Default: false)
+	;SSLConnect = yes
+
+	# Define a (case insensitive) list of masks matching nicknames that
+	# should be treated as IRC services when introduced via this remote
+	# server, separated by commas (",").
+	# REGULAR SERVERS DON'T NEED this parameter, so leave it empty
+	# (which is the default).
+	# When you are connecting IRC services which mask as a IRC server
+	# and which use "virtual users" to communicate with, for example
+	# "NickServ" and "ChanServ", you should set this parameter to
+	# something like "*Serv" or "NickServ,ChanServ,XyzServ".
+	;ServiceMask = *Serv,Global
+
+[Server]
+	# More [Server] sections, if you like ...
+
+[Channel]
+	# Pre-defined channels can be configured in [Channel] sections.
+	# Such channels are created by the server when starting up and even
+	# persist when there are no more members left.
+	# Persistent channels are marked with the mode 'P', which can be set
+	# and unset by IRC operators like other modes on the fly.
+	# There may be more than one [Channel] block, one for each channel.
+
+	# Name of the channel
+	;Name = #TheName
+
+	# Topic for this channel
+	;Topic = a great topic
+
+	# Initial channel modes
+	;Modes = tnk
+
+	# initial channel password (mode k)
+	;Key = Secret
+
+	# Key file, syntax for each line: "<user>:<nick>:<key>".
+	# Default: none.
+	;KeyFile = /etc/ngircd/#chan.key
+
+	# maximum users per channel (mode l)
+	;MaxUsers = 23
+
+[Channel]
+	# More [Channel] sections, if you like ...
+
+# -eof-

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,3 +11,15 @@ services:
     ports:
       - 6667:6667
     restart: unless-stopped
+
+  ft_irc:
+    image: ghcr.io/gawingowin/ft_irc:latest
+    container_name: ft_irc
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Asia/Tokyo
+    ports:
+      - 6668:6668
+    command: ["6668", "password"]
+    restart: unless-stopped


### PR DESCRIPTION
https://github.com/GawinGowin/ft_irc/pkgs/container/ft_irc

このlatestイメージを用い、
ポート：`6668`
パスワード： `password`
でft_ircを起動する。

- 該当のコンテナのtagとして設定されているハッシュ値は、ビルドされたft_ircのコミットハッシュに一致する。
- 比較のために、6667ポートで、ngircdを起動している
