### PR TITLE
fix: Messageの引数のパースに関して、`:`を含めず引数として扱うようにした。

### DIFF
--- a/pkg/domain/message/Message.hpp
+++ b/pkg/domain/message/Message.hpp
@@ -6,6 +6,7 @@
 #include "domain/message/PrefixInfo.hpp"
 #include <algorithm>
 #include <iomanip>
+#include <iterator>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -31,10 +32,6 @@ public:
   int parseMessage(const std::string &message);
   static int parsePrefixDetails(PrefixInfo &prefixInfo, const std::string prefix);
   static int parseCommand(MessageConstants::CommandType &command, const std::string message);
-  static int parseParams(
-      std::vector<std::string> &params,
-      std::vector<std::string>::iterator paramIter,
-      std::vector<std::string>::iterator end);
   static int parseParams(
       std::vector<std::string> &params, const std::string paramStr, int *const isIncludeTrailing);
 

--- a/tests/gtests/domain/message/test_Message.cpp
+++ b/tests/gtests/domain/message/test_Message.cpp
@@ -27,9 +27,10 @@ TEST(MessageTest, ConstructorUserCmd) {
 
   EXPECT_EQ(message.getPrefix(), "");
   EXPECT_EQ(message.getCommand(), MessageConstants::USER);
-  EXPECT_EQ(message.getParams()[0], "*");
-  EXPECT_EQ(message.getParams()[1], "0");
-  EXPECT_EQ(message.getParams()[2], "realusername");
+  EXPECT_EQ(message.getParams()[0], "me");
+  EXPECT_EQ(message.getParams()[1], "*");
+  EXPECT_EQ(message.getParams()[2], "0");
+  EXPECT_EQ(message.getParams()[3], "realusername");
 }
 
 TEST(MessageTest, ConstructorWithPrefixCommandAndParams) {

--- a/tests/gtests/domain/message/test_Message.cpp
+++ b/tests/gtests/domain/message/test_Message.cpp
@@ -12,14 +12,24 @@ TEST(MessageTest, DefaultConstructor) {
   EXPECT_EQ(message.getParams().size(), 0);
 }
 
-TEST(MessageTest, Constructor) {
+TEST(MessageTest, ConstructorResp) {
   Message message(":nick!user@host PASS your 1 1 :Current local users: 1, Max: 1\r\n");
 
   EXPECT_EQ(message.getPrefix(), ":nick!user@host");
   EXPECT_EQ(message.getParams()[0], "your");
   EXPECT_EQ(message.getParams()[1], "1");
   EXPECT_EQ(message.getParams()[2], "1");
-  EXPECT_EQ(message.getParams()[3], ":Current local users: 1, Max: 1");
+  EXPECT_EQ(message.getParams()[3], "Current local users: 1, Max: 1");
+}
+
+TEST(MessageTest, ConstructorUserCmd) {
+  Message message("USER me * 0 :realusername\r\n");
+
+  EXPECT_EQ(message.getPrefix(), "");
+  EXPECT_EQ(message.getCommand(), MessageConstants::USER);
+  EXPECT_EQ(message.getParams()[0], "*");
+  EXPECT_EQ(message.getParams()[1], "0");
+  EXPECT_EQ(message.getParams()[2], "realusername");
 }
 
 TEST(MessageTest, ConstructorWithPrefixCommandAndParams) {

--- a/tests/gtests/domain/message/test_MessageParser.cpp
+++ b/tests/gtests/domain/message/test_MessageParser.cpp
@@ -30,12 +30,12 @@ TEST(ParserTest, testPrefix) {
   EXPECT_EQ(noCRLF.getPrefix(), "");
   EXPECT_EQ(noCRLF.getCommand(), CommandType::PRIVMSG);
   EXPECT_EQ(noCRLF.getParams()[0], "#channel");
-  EXPECT_EQ(noCRLF.getParams()[1], ":Hello, world!");
+  EXPECT_EQ(noCRLF.getParams()[1], "Hello, world!");
 
   EXPECT_EQ(prefix.getPrefix(), ":prefix");
   EXPECT_EQ(prefix.getCommand(), CommandType::PRIVMSG);
   EXPECT_EQ(prefix.getParams()[0], "#channel");
-  EXPECT_EQ(prefix.getParams()[1], ":Hello, world!");
+  EXPECT_EQ(prefix.getParams()[1], "Hello, world!");
   EXPECT_EQ(noprefix.getPrefix(), "");
   EXPECT_EQ(onlyPrefix.getCommand(), CommandType::UNDEFINED);
   EXPECT_EQ(onlyPrefixAndSpace.getCommand(), CommandType::UNDEFINED);


### PR DESCRIPTION
Before
```c++
TEST(MessageTest, ConstructorUserCmd) {
  Message message("USER me * 0 :realusername\r\n");

  EXPECT_EQ(message.getPrefix(), "");
  EXPECT_EQ(message.getCommand(), MessageConstants::USER);
  EXPECT_EQ(message.getParams()[0], "me");
  EXPECT_EQ(message.getParams()[1], "*");
  EXPECT_EQ(message.getParams()[2], "0");
  EXPECT_EQ(message.getParams()[3], ":realusername");
}
```

After
```c++
TEST(MessageTest, ConstructorUserCmd) {
  Message message("USER me * 0 :realusername\r\n");

  EXPECT_EQ(message.getPrefix(), "");
  EXPECT_EQ(message.getCommand(), MessageConstants::USER);
  EXPECT_EQ(message.getParams()[0], "me");
  EXPECT_EQ(message.getParams()[1], "*");
  EXPECT_EQ(message.getParams()[2], "0");
  EXPECT_EQ(message.getParams()[3], "realusername"); // ここが変更
}
```