### PR TITLE
update: QUITコマンドの実装

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -30,7 +30,7 @@
         "${workspaceFolder}/tests/e2e/irc_e2e.py",
         "--org", "host.docker.internal:6667",
         "--alt", "host.docker.internal:6668",
-        "${workspaceFolder}/tests/e2e/certification.json",
+        "${workspaceFolder}/tests/e2e/quit.json",
       ],
       "group": "build",
     }

--- a/pkg/application/commands/Join.cpp
+++ b/pkg/application/commands/Join.cpp
@@ -69,7 +69,7 @@ SendMsgDTO Join::execute() {
       channelDB.add(Channel(channels[i]));
       channel = channelDB.get(channels[i]);
       channel->addOperator(client->getNickName());
-      logger->debugss() << "[JOIN] (fd: " << client->getSocketFd() << "): create" << channels[i];
+      logger->debugss() << "[JOIN] (fd: " << client->getSocketFd() << "): create " << channels[i];
     } else {
       // パスワードのチェック
       if (!channel->checkKey(password)) {
@@ -100,6 +100,7 @@ SendMsgDTO Join::execute() {
       generateChannelInfoResponse(messageStreams, socketHandler, client, channel);
     }
   }
+  logger->debugss() << "Total Channels Count: " << channels.size();
   return SendMsgDTO(0, messageStreams);
 }
 

--- a/pkg/application/commands/Quit.cpp
+++ b/pkg/application/commands/Quit.cpp
@@ -78,12 +78,13 @@ SendMsgDTO Quit::execute() {
     ChannelClientList &clientList = channel->getListConnects();
 
     if (clientList.getClients().empty()) {
-      this->_logger->debugss() << "Channel " << channel->getName() << " is empty, removing it";
+      this->_logger->tracess() << "Channel " << channel->getName() << " is empty, removing it";
       this->_channelDB->remove(channel->getName());
     }
   }
   // CLIENT_DISCONNECT にすれば後の処理で自動的に切断される。
   client->setClientType(CLIENT_DISCONNECT);
   // _clientDBからクライアントを削除する手続きはRemoveConnectionUseCase::removeで行われる
+  this->_logger->debugss() << "Total Channels Count: " << channels.size();
   return SendMsgDTO(0, messageStreams);
 }

--- a/pkg/application/commands/Quit.cpp
+++ b/pkg/application/commands/Quit.cpp
@@ -1,0 +1,71 @@
+#include "application/commands/Quit.hpp"
+
+Quit::Quit(IMessageAggregateRoot *msg, IClientAggregateRoot *client) : ACommands(msg, client) {
+  this->_channelDB = &InmemoryChannelDBServiceLocator::get();
+  this->_clientDB = &InmemoryClientDBServiceLocator::get();
+  this->_logger = LoggerServiceLocator::get();
+  this->_conf = &ConfigsServiceLocator::get();
+  this->_socketHandler = &SocketHandlerServiceLocator::get();
+}
+
+SendMsgDTO Quit::execute() {
+  // IMessageAggregateRoot *msg = this->getMessage();
+  IClientAggregateRoot *client = this->getClient();
+
+  MessageStreamVector messageStreams;
+
+  // 離脱するClientと同じチャンネルに所属する人にQuitメッセージを送信する
+  const std::string quitMessage = ":Client closed connection";
+  const std::string prefix =
+      client->getNickName() + "!" + client->getUserName() + "@" + client->getAddress();
+  std::stringstream quitMsgss;
+  quitMsgss << Message(prefix, MessageConstants::QUIT, quitMessage);
+  const IdToChannelMap &channels = this->_channelDB->getDatabase();
+  std::map<std::string, IClientAggregateRoot *> clientQuitTargetsMap;
+  for (IdToChannelMap::const_iterator it = channels.begin(); it != channels.end(); ++it) {
+    IChannelAggregateRoot *channel = it->second;
+
+    ChannelClientList &clientList = channel->getListConnects();
+    if (clientList.isClientInList(client->getId())) {
+
+      const std::vector<std::string> &members = clientList.getClients();
+      for (std::vector<std::string>::const_iterator it = members.begin(); it != members.end();
+           ++it) {
+        IClientAggregateRoot *member = this->_clientDB->getById(*it);
+        if (member && member->getId() != client->getId()) {
+          clientQuitTargetsMap[*it] = member;
+        }
+      }
+    }
+  }
+  if (!clientQuitTargetsMap.empty()) {
+    for (std::map<std::string, IClientAggregateRoot *>::const_iterator it =
+             clientQuitTargetsMap.begin();
+         it != clientQuitTargetsMap.end(); ++it) {
+      MessageStream stream(this->_socketHandler, it->second);
+      stream << quitMsgss.str();
+      messageStreams.push_back(stream);
+    }
+  }
+
+  // チャンネルからクライアントを削除
+  ChannelService::removeClientFromAllChannels(client->getId());
+
+  this->_logger->debugss() << client->getId() << "(fd:" << client->getSocketFd()
+                           << ") removed from all channels";
+
+  // ユーザーが空ならば、チャンネルを削除する
+  for (IdToChannelMap::const_iterator it = channels.begin(); it != channels.end(); ++it) {
+    IChannelAggregateRoot *channel = it->second;
+    ChannelClientList &clientList = channel->getListConnects();
+
+    if (clientList.getClients().empty()) {
+      this->_logger->debugss() << "Channel " << channel->getName() << " is empty, removing it";
+      this->_channelDB->remove(channel->getName());
+    }
+  }
+  // CLIENT_DISCONNECT にすれば後の処理で自動的に切断される。
+  client->setClientType(CLIENT_DISCONNECT);
+  // _clientDBからクライアントを削除する手続きはRemoveConnectionUseCase::removeで行われる
+  return SendMsgDTO(0, messageStreams);
+}

--- a/pkg/application/commands/Quit.hpp
+++ b/pkg/application/commands/Quit.hpp
@@ -1,0 +1,29 @@
+#ifndef QUIT_HPP
+#define QUIT_HPP
+
+#include "application/commands/ACommands.hpp"
+#include "application/serviceLocator/ConfigsServiceLocator.hpp"
+#include "application/serviceLocator/InmemoryChannelDBServiceLocator.hpp"
+#include "application/serviceLocator/InmemoryClientDBServiceLocator.hpp"
+#include "application/serviceLocator/LoggerServiceLocator.hpp"
+#include "application/serviceLocator/SocketHandlerServiceLocator.hpp"
+#include "domain/channel/Channel.hpp"
+#include "domain/channel/ChannelService.hpp"
+#include "domain/client/IClientAggregateRoot.hpp"
+#include "domain/message/IMessageAggregateRoot.hpp"
+#include "domain/message/MessageService.hpp"
+
+class Quit : public ACommands {
+public:
+  Quit(IMessageAggregateRoot *msg, IClientAggregateRoot *client);
+  SendMsgDTO execute();
+
+private:
+  InmemoryChannelDatabase *_channelDB;
+  InmemoryClientDatabase *_clientDB;
+  MultiLogger *_logger;
+  ConfigsLoader *_conf;
+  ISocketHandler *_socketHandler;
+};
+
+#endif /* QUIT_HPP */

--- a/pkg/application/useCases/RemoveConnectionUseCase.cpp
+++ b/pkg/application/useCases/RemoveConnectionUseCase.cpp
@@ -9,11 +9,6 @@ void RemoveConnectionUseCase::remove(int clientFd) {
     if (client == NULL) {
       throw std::runtime_error("Client not found unexpectedly");
     }
-    ChannelService::removeClientFromAllChannels(client->getId());
-    logger->debugss() << client->getId() << "(fd:" << clientFd << ") removed from all channels";
-
-    // TODO: ユーザーが空ならば、チャンネルを削除する機構を追加する
-
     db->remove(client->getId());
     _socketHandler->closeConnection(clientFd);
     logger->infoss() << "Connection closed: (fd:" << clientFd << ")";

--- a/pkg/application/useCases/RemoveConnectionUseCase.cpp
+++ b/pkg/application/useCases/RemoveConnectionUseCase.cpp
@@ -3,11 +3,19 @@
 void RemoveConnectionUseCase::remove(int clientFd) {
   SocketHandler *_socketHandler = &SocketHandlerServiceLocator::get();
   InmemoryClientDatabase *db = &InmemoryClientDBServiceLocator::get();
+  MultiLogger *logger = LoggerServiceLocator::get();
   try {
-    MultiLogger *logger = LoggerServiceLocator::get();
+    IClientAggregateRoot *client = db->getByFd(clientFd);
+    if (client == NULL) {
+      throw std::runtime_error("Client not found unexpectedly");
+    }
+    ChannelService::removeClientFromAllChannels(client->getId());
+    logger->debugss() << client->getId() << "(fd:" << clientFd << ") removed from all channels";
+
+    // TODO: ユーザーが空ならば、チャンネルを削除する機構を追加する
+
+    db->remove(client->getId());
     _socketHandler->closeConnection(clientFd);
-    db->removeFdsByFd(clientFd);
-    // TODO: チャンネルからもユーザーを削除する処理を追加
     logger->infoss() << "Connection closed: (fd:" << clientFd << ")";
   } catch (const std::runtime_error &e) {
     throw std::runtime_error(std::string("Remove connection: ") + e.what());

--- a/pkg/application/useCases/RemoveConnectionUseCase.cpp
+++ b/pkg/application/useCases/RemoveConnectionUseCase.cpp
@@ -5,11 +5,7 @@ void RemoveConnectionUseCase::remove(int clientFd) {
   InmemoryClientDatabase *db = &InmemoryClientDBServiceLocator::get();
   MultiLogger *logger = LoggerServiceLocator::get();
   try {
-    IClientAggregateRoot *client = db->getByFd(clientFd);
-    if (client == NULL) {
-      throw std::runtime_error("Client not found unexpectedly");
-    }
-    db->remove(client->getId());
+    db->removeFdsByFd(clientFd);
     _socketHandler->closeConnection(clientFd);
     logger->infoss() << "Connection closed: (fd:" << clientFd << ")";
   } catch (const std::runtime_error &e) {

--- a/pkg/application/useCases/RemoveConnectionUseCase.hpp
+++ b/pkg/application/useCases/RemoveConnectionUseCase.hpp
@@ -4,6 +4,7 @@
 #include "application/serviceLocator/InmemoryClientDBServiceLocator.hpp"
 #include "application/serviceLocator/LoggerServiceLocator.hpp"
 #include "application/serviceLocator/SocketHandlerServiceLocator.hpp"
+#include "domain/channel/ChannelService.hpp"
 #include "domain/client/Client.hpp"
 #include "infra/logger/MultiLogger.hpp"
 

--- a/pkg/application/useCases/RunCommandsUseCase.cpp
+++ b/pkg/application/useCases/RunCommandsUseCase.cpp
@@ -2,13 +2,13 @@
 
 SendMsgDTO RunCommandsUseCase::execute(RecievedMsgDTO &recieved) {
   MultiLogger *logger = LoggerServiceLocator::get();
+  Message clientMsg;
   if (recieved.getMessage().empty()) {
-    logger->error("Recieved message is empty");
-    throw std::invalid_argument("Recieved message is empty");
+    logger->debug("Recieved message is empty");
+  } else {
+    clientMsg = Message(recieved.getMessage());
+    logger->tracess() << "Recieved message: " << clientMsg;
   }
-  Message clientMsg(recieved.getMessage());
-  logger->tracess() << "clientMsg: " << clientMsg;
-
   SendMsgDTO dto;
   IClientAggregateRoot *client = recieved.getClient();
   switch (clientMsg.getCommand()) {
@@ -40,8 +40,9 @@ SendMsgDTO RunCommandsUseCase::execute(RecievedMsgDTO &recieved) {
     dto = Mode(&clientMsg, client).execute();
     break;
   case (MessageConstants::QUIT):
+  case (MessageConstants::UNDEFINED):
     dto = Quit(&clientMsg, client).execute();
-    return (dto);
+    break;
   case (MessageConstants::ERROR):
     dto.setStatus(1);
     return (dto);

--- a/pkg/application/useCases/RunCommandsUseCase.cpp
+++ b/pkg/application/useCases/RunCommandsUseCase.cpp
@@ -39,6 +39,9 @@ SendMsgDTO RunCommandsUseCase::execute(RecievedMsgDTO &recieved) {
   case (MessageConstants::MODE):
     dto = Mode(&clientMsg, client).execute();
     break;
+  case (MessageConstants::QUIT):
+    dto = Quit(&clientMsg, client).execute();
+    return (dto);
   case (MessageConstants::ERROR):
     dto.setStatus(1);
     return (dto);

--- a/pkg/application/useCases/RunCommandsUseCase.cpp
+++ b/pkg/application/useCases/RunCommandsUseCase.cpp
@@ -3,14 +3,14 @@
 SendMsgDTO RunCommandsUseCase::execute(RecievedMsgDTO &recieved) {
   MultiLogger *logger = LoggerServiceLocator::get();
   Message clientMsg;
+  IClientAggregateRoot *client = recieved.getClient();
   if (recieved.getMessage().empty()) {
-    logger->debug("Recieved message is empty");
+    logger->warningss() << "Recieved message is empty (fd: " << client->getSocketFd() << ")";
   } else {
     clientMsg = Message(recieved.getMessage());
     logger->tracess() << "Recieved message: " << clientMsg;
   }
   SendMsgDTO dto;
-  IClientAggregateRoot *client = recieved.getClient();
   switch (clientMsg.getCommand()) {
   case (MessageConstants::PASS):
     dto = Pass(&clientMsg, client).execute();

--- a/pkg/application/useCases/RunCommandsUseCase.hpp
+++ b/pkg/application/useCases/RunCommandsUseCase.hpp
@@ -8,6 +8,7 @@
 #include "application/commands/Nick.hpp"
 #include "application/commands/Pass.hpp"
 #include "application/commands/Privmsg.hpp"
+#include "application/commands/Quit.hpp"
 #include "application/commands/Topic.hpp"
 #include "application/commands/User.hpp"
 #include "application/dto/RecievedMsgDTO.hpp"

--- a/pkg/domain/message/Message.cpp
+++ b/pkg/domain/message/Message.cpp
@@ -269,6 +269,8 @@ inline static MessageConstants::CommandType strToCommandType(const std::string &
     return (MessageConstants::TOPIC);
   } else if (str == "MODE") {
     return (MessageConstants::MODE);
+  } else if (str == "QUIT") {
+    return (MessageConstants::QUIT);
   } else {
     return (MessageConstants::UNKNOWN);
   }
@@ -294,6 +296,8 @@ inline static std::string enumToCommandStr(const MessageConstants::CommandType &
     return "TOPIC";
   case MessageConstants::MODE:
     return "MODE";
+  case MessageConstants::QUIT:
+    return "QUIT";
   case MessageConstants::ERROR:
     return "ERROR";
   default:

--- a/pkg/domain/message/MessageConstants.hpp
+++ b/pkg/domain/message/MessageConstants.hpp
@@ -14,6 +14,7 @@ enum CommandType {
   INVITE,
   TOPIC,
   MODE,
+  QUIT,
   ERROR,
   UNKNOWN,
   UNDEFINED

--- a/pkg/presentation/entrypoint.cpp
+++ b/pkg/presentation/entrypoint.cpp
@@ -40,11 +40,6 @@ void entrypoint(int argc, char **argv) {
       break;
     case MonitorSocketEventDTO::MessageReceived:
       recievedMsgDto = RecieveMsgUseCase::recieve(eventDto);
-      if (recievedMsgDto.getMessage().size() == 0) {
-        int clientFd = eventDto.getConnectionFd();
-        RemoveConnectionUseCase::remove(clientFd);
-        break;
-      }
       sendMsgDto = RunCommandsUseCase::execute(recievedMsgDto);
       SendMsgFromServerUseCase::send(sendMsgDto);
       if (recievedMsgDto.getClient()->getClientType() & CLIENT_DISCONNECT) {

--- a/tests/e2e/quit.json
+++ b/tests/e2e/quit.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "QUIT",
+    "commands": [
+      ["PASS password", 0.8],
+      ["NICK testuser", 0.8],
+      ["USER testuser 0 * :Test User", 1.0],
+      ["JOIN #test", 0.8],
+      ["QUIT", 0.8]
+    ]
+  },
+  {
+    "name": "QUIT_msg_tail",
+    "commands": [
+      ["PASS password", 0.8],
+      ["NICK testuser", 0.8],
+      ["USER testuser 0 * :Test User", 1.0],
+      ["JOIN #test", 0.8],
+      ["QUIT :aaaaaa", 0.8]
+    ]
+  },
+  {
+    "name": "QUIT_msg_1_arg",
+    "commands": [
+      ["PASS password", 0.8],
+      ["NICK testuser", 0.8],
+      ["USER testuser 0 * :Test User", 1.0],
+      ["JOIN #test", 0.8],
+      ["QUIT aaaaaa", 0.8]
+    ]
+  },
+  {
+    "name": "QUIT_msg_2_arg",
+    "commands": [
+      ["PASS password", 0.8],
+      ["NICK testuser", 0.8],
+      ["USER testuser 0 * :Test User", 1.0],
+      ["JOIN #test", 0.8],
+      ["QUIT aaaaaa bbbbbbb", 0.8]
+    ]
+  }
+]


### PR DESCRIPTION
QUITコマンドの仕様としての、離脱時にチャンネルから離脱した旨のメッセージが配信されるようにしている。
- 複数のチャンネルに所属していたとき、関係者には一つだけのQUITメッセージが配信される。
- QUITした際、チャンネルが空なら削除される。
- チャンネルオペレータがQUITした際、オペレータは変更されないというのはngircdと同様。

**これはクライアントが、Ctrl + Cで離脱した時も同様。**

PARTコマンドについては現状実装していない。

![image](https://github.com/user-attachments/assets/20b860c5-c8c8-4369-abf4-6404464b8d13)

