### PR TITLE
fix: 130-応答メッセージの拡充

### DIFF
--- a/pkg/application/commands/Nick.cpp
+++ b/pkg/application/commands/Nick.cpp
@@ -53,9 +53,7 @@ SendMsgDTO Nick::execute() {
   ClientService::LoginResult ret = ClientService::login(*client);
   switch (ret) {
   case ClientService::LOGIN_SUCCESS:
-    stream << Message(
-        serverName, MessageConstants::ResponseCode::RPL_WELCOME,
-        client->getNickName() + " :" + ClientService::generateWelcomeMessage(*client));
+    ClientService::writeWelcomeMessageToStream(stream, *client);
     messageStreams.push_back(stream);
     break;
   case ClientService::LOGIN_FAILED:

--- a/pkg/application/commands/User.cpp
+++ b/pkg/application/commands/User.cpp
@@ -46,9 +46,7 @@ SendMsgDTO User::execute() {
     ClientService::LoginResult ret = ClientService::login(*client);
     switch (ret) {
     case ClientService::LOGIN_SUCCESS:
-      stream << Message(
-          serverName, MessageConstants::ResponseCode::RPL_WELCOME,
-          client->getNickName() + " :" + ClientService::generateWelcomeMessage(*client));
+      ClientService::writeWelcomeMessageToStream(stream, *client);
       messageStreams.push_back(stream);
       break;
     case ClientService::LOGIN_FAILED:

--- a/pkg/application/useCases/StartServerUseCase.cpp
+++ b/pkg/application/useCases/StartServerUseCase.cpp
@@ -4,6 +4,7 @@ StartServerUseCase::StartServerUseCase(const StartServerDTO &dto) {
   ConfigsLoader &loader = ConfigsServiceLocator::get();
   loader.setPort(dto.getPort());
   loader.setPassword(dto.getPassword());
+  loader.setStartStr();
   const Configs &conf = loader.getConfigs();
   try {
     SocketHandlerServiceLocator::init(

--- a/pkg/domain/client/ClientService.cpp
+++ b/pkg/domain/client/ClientService.cpp
@@ -32,3 +32,29 @@ std::string ClientService::generateWelcomeMessage(IClientAggregateRoot &client) 
   return "Welcome to the Internet Relay Network " + client.getNickName() + "!" +
          client.getUserName() + "@" + client.getAddress();
 }
+
+void ClientService::writeWelcomeMessageToStream(MessageStream &stream,
+                                                 IClientAggregateRoot &client) {
+  stream << Message(
+      ConfigsServiceLocator::get().getConfigs().Global.Name,
+      MessageConstants::ResponseCode::RPL_WELCOME,
+      client.getNickName() + " :" + ClientService::generateWelcomeMessage(client));
+  stream << Message(
+      ConfigsServiceLocator::get().getConfigs().Global.Name,
+      MessageConstants::ResponseCode::RPL_YOURHOST,
+      client.getNickName() + " :Your host is " +
+          ConfigsServiceLocator::get().getConfigs().Global.Name + ", running version " +
+          ConfigsServiceLocator::get().getConfigs().Global.Version);
+  stream << Message(
+      ConfigsServiceLocator::get().getConfigs().Global.Name,
+      MessageConstants::ResponseCode::RPL_CREATED,
+      client.getNickName() + " :This server was created " +
+          ConfigsServiceLocator::get().getConfigs().Global.StartStr);
+  stream << Message(
+      ConfigsServiceLocator::get().getConfigs().Global.Name,
+      MessageConstants::ResponseCode::RPL_MYINFO,
+      client.getNickName() + " " + ConfigsServiceLocator::get().getConfigs().Global.Name +
+          " " + ConfigsServiceLocator::get().getConfigs().Global.Version + " " +
+          ConfigsServiceLocator::get().getConfigs().Global.UserModes + " " +
+          ConfigsServiceLocator::get().getConfigs().Global.ChanModes);
+}

--- a/pkg/domain/client/ClientService.cpp
+++ b/pkg/domain/client/ClientService.cpp
@@ -33,8 +33,8 @@ std::string ClientService::generateWelcomeMessage(IClientAggregateRoot &client) 
          client.getUserName() + "@" + client.getAddress();
 }
 
-void ClientService::writeWelcomeMessageToStream(MessageStream &stream,
-                                                 IClientAggregateRoot &client) {
+void ClientService::writeWelcomeMessageToStream(
+    MessageStream &stream, IClientAggregateRoot &client) {
   stream << Message(
       ConfigsServiceLocator::get().getConfigs().Global.Name,
       MessageConstants::ResponseCode::RPL_WELCOME,
@@ -53,8 +53,8 @@ void ClientService::writeWelcomeMessageToStream(MessageStream &stream,
   stream << Message(
       ConfigsServiceLocator::get().getConfigs().Global.Name,
       MessageConstants::ResponseCode::RPL_MYINFO,
-      client.getNickName() + " " + ConfigsServiceLocator::get().getConfigs().Global.Name +
-          " " + ConfigsServiceLocator::get().getConfigs().Global.Version + " " +
+      client.getNickName() + " " + ConfigsServiceLocator::get().getConfigs().Global.Name + " " +
+          ConfigsServiceLocator::get().getConfigs().Global.Version + " " +
           ConfigsServiceLocator::get().getConfigs().Global.UserModes + " " +
           ConfigsServiceLocator::get().getConfigs().Global.ChanModes);
 }

--- a/pkg/domain/client/ClientService.hpp
+++ b/pkg/domain/client/ClientService.hpp
@@ -4,6 +4,9 @@
 #include "application/serviceLocator/ConfigsServiceLocator.hpp"
 #include "domain/client/IClientAggregateRoot.hpp"
 #include "domain/client/Password.hpp"
+#include "domain/message/MessageService.hpp"
+#include "domain/message/IMessageAggregateRoot.hpp"
+#include "domain/message/Message.hpp"
 
 #include <string>
 
@@ -17,6 +20,7 @@ public:
   };
   static LoginResult login(IClientAggregateRoot &client);
   static std::string generateWelcomeMessage(IClientAggregateRoot &client);
+  static void writeWelcomeMessageToStream(MessageStream &stream, IClientAggregateRoot &client);
 };
 
 #endif /* CLIENTSERVICE_HPP */

--- a/pkg/domain/client/ClientService.hpp
+++ b/pkg/domain/client/ClientService.hpp
@@ -4,9 +4,9 @@
 #include "application/serviceLocator/ConfigsServiceLocator.hpp"
 #include "domain/client/IClientAggregateRoot.hpp"
 #include "domain/client/Password.hpp"
-#include "domain/message/MessageService.hpp"
 #include "domain/message/IMessageAggregateRoot.hpp"
 #include "domain/message/Message.hpp"
+#include "domain/message/MessageService.hpp"
 
 #include <string>
 

--- a/pkg/domain/configs/GlobalConfig.hpp
+++ b/pkg/domain/configs/GlobalConfig.hpp
@@ -20,6 +20,10 @@ struct GlobalConfig {
   int Port;
   std::string ServerGID;
   std::string ServerUID;
+  std::string Version;
+  std::string StartStr;
+  std::string UserModes;
+  std::string ChanModes;
 };
 
 #endif /* GLOBALCONFIG_HPP */

--- a/pkg/domain/message/MessageConstants.hpp
+++ b/pkg/domain/message/MessageConstants.hpp
@@ -25,6 +25,8 @@ enum CommandType {
 namespace ResponseCode {
 const int RPL_WELCOME = 1;
 const int RPL_YOURHOST = 2;
+const int RPL_CREATED = 3;
+const int RPL_MYINFO = 4;
 const int RPL_CHANNELMODEIS = 324;
 const int RPL_CREATIONTIME_MSG = 329;
 const int RPL_TOPIC = 332;

--- a/pkg/infra/configs/ConfigsLoader.cpp
+++ b/pkg/infra/configs/ConfigsLoader.cpp
@@ -19,6 +19,10 @@ ConfigsLoader::ConfigsLoader() {
   conf.Global.Port = 6667;
   conf.Global.ServerGID = "irc";
   conf.Global.ServerUID = "irc";
+  conf.Global.Version = "ft_irc-1.0";
+  conf.Global.StartStr = "Fri Apr 04 2025 at 19:40:56 (JST)";
+  conf.Global.UserModes = "o";
+  conf.Global.ChanModes = "iklot";
 
   // [Limits]
   conf.Limits.ConnectRetry = 60;
@@ -80,4 +84,13 @@ void ConfigsLoader::setPort(const int &port) { this->_configs.Global.Port = port
 
 void ConfigsLoader::setPassword(const std::string &password) {
   this->_configs.Global.Password = password;
+}
+
+void ConfigsLoader::setStartStr() {
+  std::time_t now = std::time(NULL);
+  std::tm *tm = std::localtime(&now);
+
+  char buffer[50];
+  std::strftime(buffer, sizeof(buffer), "%a %b %d %Y at %H:%M:%S (JST)", tm);
+  this->_configs.Global.StartStr = std::string(buffer);
 }

--- a/pkg/infra/configs/ConfigsLoader.hpp
+++ b/pkg/infra/configs/ConfigsLoader.hpp
@@ -3,6 +3,9 @@
 
 #include "domain/configs/Configs.hpp"
 #include "domain/configs/IConfigsRepository.hpp"
+#include <ctime>
+#include <sstream>
+
 
 class ConfigsLoader : virtual public IConfigsRepository {
 public:
@@ -16,6 +19,7 @@ public:
 
   void setPort(const int &port);
   void setPassword(const std::string &password);
+  void setStartStr();
 
 private:
   Configs _configs;

--- a/pkg/infra/configs/ConfigsLoader.hpp
+++ b/pkg/infra/configs/ConfigsLoader.hpp
@@ -6,7 +6,6 @@
 #include <ctime>
 #include <sstream>
 
-
 class ConfigsLoader : virtual public IConfigsRepository {
 public:
   ConfigsLoader();


### PR DESCRIPTION
- 応答メッセージ001~004をstreamに追加する関数`writeWelcomeMessageToStream`の作成
- https://github.com/GawinGowin/ft_irc/issues/140 により、004の最後に:が付加されているため、これを取り除く必要あり。

```
syamasaw@ubuntu24:~$ nc -C 127.0.0.1 8081
PASS pass
NICK sya
USER g * * h
:irc.example.net 001 sya :Welcome to the Internet Relay Network sya!~g@127.0.0.1
:irc.example.net 002 sya :Your host is irc.example.net, running version ft_irc-1.0
:irc.example.net 003 sya :This server was created Fri Apr 04 2025 at 21:25:25 (JST)
:irc.example.net 004 sya irc.example.net ft_irc-1.0 o :iklot
^C
syamasaw@ubuntu24:~$ nc -C 127.0.0.1 8081
PASS pass
USER g * * h
NICK sya
:irc.example.net 001 sya :Welcome to the Internet Relay Network sya!~g@127.0.0.1
:irc.example.net 002 sya :Your host is irc.example.net, running version ft_irc-1.0
:irc.example.net 003 sya :This server was created Fri Apr 04 2025 at 21:25:25 (JST)
:irc.example.net 004 sya irc.example.net ft_irc-1.0 o :iklot

```